### PR TITLE
Fixing the electron-packager generator issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,73 @@
 {
-  "name": "proton-template-app",
-  "version": "1.0.0",
-  "description": "A simple template app for Proton",
-  "main": "app.js",
+  "name": "photon",
+  "version": "0.1.2",
   "author": "Connor Sears",
-  "scripts": {
-    "start": "electron ."
+  "main": "dist/template-app/app.js",
+  "keywords": [
+    "photon",
+    "html",
+    "css",
+    "electron"
+  ],
+  "style": "dist/css/photon.css",
+  "sass": "sass/photon.scss",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/connors/photon.git"
   },
+  "bugs": {
+    "url": "https://github.com/connors/photon/issues"
+  },
+  "scripts": {
+    "start": "electron -v & electron dist/template-app",
+    "build": "grunt"
+  },
+  "license": "MIT",
   "devDependencies": {
+    "electron-settings": "^3.1.4",
+    "grunt": "~0.4.5",
+    "grunt-banner": "~0.5.0",
+    "grunt-cli": "^0.1.13",
+    "grunt-contrib-clean": "~0.6.0",
+    "grunt-contrib-compress": "~0.13.0",
+    "grunt-contrib-concat": "~0.5.1",
+    "grunt-contrib-connect": "~0.11.2",
+    "grunt-contrib-copy": "~0.8.0",
+    "grunt-contrib-cssmin": "~0.13.0",
+    "grunt-contrib-sass": "~0.9.2",
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-html": "~5.0.0",
+    "grunt-jekyll": "~0.4.2",
+    "grunt-sed": "twbs/grunt-sed#v0.2.0",
+    "load-grunt-tasks": "~3.2.0",
+    "node-schedule": "^1.2.5",
     "node-ssdp": "git+https://github.com/Sanji-IO/node-ssdp.git",
-    "electron-settings": "^3.1.3"
+    "time-grunt": "~1.2.0",
+    "xml2js": "^0.4.19",
+    "xmldoc": "^1.1.0"
+  },
+  "dependencies": {
+    "request": "^2.83.0",
+    "electron-settings": "^3.1.4",
+    "grunt": "~0.4.5",
+    "grunt-banner": "~0.5.0",
+    "grunt-cli": "^0.1.13",
+    "grunt-contrib-clean": "~0.6.0",
+    "grunt-contrib-compress": "~0.13.0",
+    "grunt-contrib-concat": "~0.5.1",
+    "grunt-contrib-connect": "~0.11.2",
+    "grunt-contrib-copy": "~0.8.0",
+    "grunt-contrib-cssmin": "~0.13.0",
+    "grunt-contrib-sass": "~0.9.2",
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-html": "~5.0.0",
+    "grunt-jekyll": "~0.4.2",
+    "grunt-sed": "twbs/grunt-sed#v0.2.0",
+    "load-grunt-tasks": "~3.2.0",
+    "node-schedule": "^1.2.5",
+    "node-ssdp": "git+https://github.com/Sanji-IO/node-ssdp.git",
+    "time-grunt": "~1.2.0",
+    "xml2js": "^0.4.19",
+    "xmldoc": "^1.1.0"
   }
 }


### PR DESCRIPTION
electron-packager look for the "main" tag in package.json. Unattended of "main" tag will caused node_modules & dependency packages fail to include during executable file generation.